### PR TITLE
Add reset_ratelimit method.

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -83,6 +83,7 @@ class RateLimitDecorator(object):
                     return
 
             return func(*args, **kargs)
+        wrapper.reset_ratelimit = self.reset_ratelimit
         return wrapper
 
     def __period_remaining(self):
@@ -94,6 +95,12 @@ class RateLimitDecorator(object):
         '''
         elapsed = self.clock() - self.last_reset
         return self.period - elapsed
+    
+    def reset_ratelimit(self):
+        '''
+        Reset the ratelimit.
+        '''
+        self.last_reset = self.clock()
 
 def sleep_and_retry(func):
     '''


### PR DESCRIPTION
Add a reset_ratelimit method.

This mostly useful during unit testing.

Use case:  I have a large amount of unit tests, a lot of them indirectly call my ratelimited function.
I tried a lot of other things to get round this, but this seemed to work the best (in combination with faketime so things run instantly).